### PR TITLE
Filter files by ".eex" extension when scanning template directory

### DIFF
--- a/lib/glayu/template.ex
+++ b/lib/glayu/template.ex
@@ -1,6 +1,7 @@
 defmodule Glayu.Template do
 
   @base_layout "layout"
+  @template_extension ".eex"
 
   alias Glayu.Build.TemplatesStore
 
@@ -17,7 +18,10 @@ defmodule Glayu.Template do
   end
 
   defp compile_tpls(base_path) do
-    Enum.map(File.ls!(base_path), fn(file) ->
+    base_path
+    |> File.ls!
+    |> Enum.filter(fn(file) -> Path.extname(file) == @template_extension end)
+    |> Enum.map(fn(file) ->
       compiled = EEx.compile_file(Path.join(base_path, file), [engine: Glayu.EEx.GlayuEngine])
       [name|_] = String.split(file, ".")
       {String.to_atom(name), compiled}


### PR DESCRIPTION
Hi! I have had an issue for a while getting " invalid encoding starting at <<189, 124, 89...etc" errors when running `glayu build`, also without any stack trace which made debugging quite difficult. The error was very erratic and eventually found it it disappeared when I closed my editor. Realized that the error was because of vim's swap files (".home.eex.swp" for example) for files I'm working on in the template directories. :) This patch should fix this issue. I have not built and included a new binary with this patch, as I'm not really sure how you like to do this.